### PR TITLE
swap master for main (libpysal)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -61,7 +61,7 @@
        - name: install bleeding edge libpysal (Ubuntu / Python 3.11)
          shell: bash -l {0}
          run: |
-           pip install git+https://github.com/pysal/libpysal.git@master
+           pip install git+https://github.com/pysal/libpysal.git@main
          if: matrix.os == 'ubuntu-latest' && contains(matrix.environment-file, 'DEV')
        
        - name: run tests - bash


### PR DESCRIPTION
swap `libpysal@master` for `libpysal@main` in bleeding edge testing for resolve [current CI failures](https://github.com/pysal/inequality/actions/runs/4474372906/jobs/7862775613#step:4:13).