### PR TITLE
Update requirements.txt – no `numpy>=1.3`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 scipy>=0.11
-numpy>=1.3
+numpy>=1.23


### PR DESCRIPTION
Same issue as https://github.com/pysal/spreg/pull/124, no `numpy>=1.3`