### PR TITLE
CI: install shapely dev against numpy nightly

### DIFF
--- a/ci/312-DEV.yaml
+++ b/ci/312-DEV.yaml
@@ -15,5 +15,5 @@ dependencies:
     - --pre --index-url   https://pypi.anaconda.org/scientific-python-nightly-wheels/simple   --extra-index-url https://pypi.org/simple
     - numpy
     - scipy
-    - git+https://github.com/pysal/libpysal.git@main
     - git+https://github.com/shapely/shapely.git@main
+    - git+https://github.com/pysal/libpysal.git@main

--- a/ci/312-DEV.yaml
+++ b/ci/312-DEV.yaml
@@ -3,6 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12
+  - geos
+  - Cython
   # testing
   - pytest
   - pytest-cov
@@ -14,3 +16,4 @@ dependencies:
     - numpy
     - scipy
     - git+https://github.com/pysal/libpysal.git@main
+    - git+https://github.com/shapely/shapely.git@main


### PR DESCRIPTION
I believe this should fix the DEV failures.