### PR TITLE
remove print statements

### DIFF
--- a/inequality/utils.py
+++ b/inequality/utils.py
@@ -34,11 +34,11 @@ def compute_mean(data):
 
 
 # Usage
-df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-print(compute_mean(df, column="a"))  # Output: 2.5
+# df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+# print(compute_mean(df, column="a"))  # Output: 2.5
 
-arr = np.array([1, 2, 3, 4])
-print(compute_mean(arr))  # Output: 2.5
+# arr = np.array([1, 2, 3, 4])
+# print(compute_mean(arr))  # Output: 2.5
 
-lst = [1, 2, 3, 4]
-print(compute_mean(lst))  # Output: 2.5
+# lst = [1, 2, 3, 4]
+# print(compute_mean(lst))  # Output: 2.5


### PR DESCRIPTION
As @jGaboardi pointed out in https://github.com/pysal/momepy/issues/679#issuecomment-2616554968, inequality prints three lines of values on import.

Just commenting it out as I am not sure if there's some use for that.